### PR TITLE
py-polars MSRV 1.65 -> 1.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ point to the `main` branch of this repo.
 polars = { git = "https://github.com/pola-rs/polars", rev = "<optional git tag>" }
 ```
 
-Required Rust version `>=1.65`.
+Required Rust version `>=1.70`.
 
 ## Contributing
 


### PR DESCRIPTION
py-polars depending on `polars-arrow` should have stated  MSRV 1.70 
https://github.com/pola-rs/polars/issues/10509